### PR TITLE
Fix month capitalization for date formatting

### DIFF
--- a/composeApp/src/commonMain/kotlin/fit/spotted/app/utils/DateTimeUtils.kt
+++ b/composeApp/src/commonMain/kotlin/fit/spotted/app/utils/DateTimeUtils.kt
@@ -36,7 +36,10 @@ object DateTimeUtils {
             else -> {
                 // For older posts, show month and day
                 val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
-                val month = localDateTime.month.name.take(3)
+                val month = localDateTime.month.name
+                    .lowercase()
+                    .replaceFirstChar { it.uppercase() }
+                    .take(3)
                 val day = localDateTime.dayOfMonth
                 "$month $day"
             }


### PR DESCRIPTION
## Summary
- fix month abbreviation capitalization in `DateTimeUtils`

## Testing
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684084f05328832f9313b3b0640fac26